### PR TITLE
callable Payjp object

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,10 @@
 {
-  "stage": 0,
-  "sourceMaps": true
+  "sourceMaps": true,
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "add-module-exports",
+    "transform-es2015-modules-commonjs"
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,11 +6,6 @@ env:
   es6: true
 
 globals:
-  document: false
-  Payjp: false
-  window: false
-  navigator: false
-  alert: false
   describe: false
   it: false
   before: false

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "test": "./node_modules/.bin/mocha --compilers js:espower-babel/guess test/**/*.js",
-    "build": "./node_modules/babel/bin/babel.js ./src --out-dir ./lib",
+    "build": "./node_modules/babel-cli/bin/babel.js ./src --out-dir ./lib",
     "lint": "./node_modules/eslint/bin/eslint.js src",
     "prepublish": "npm run build"
   },
@@ -29,19 +29,22 @@
     "npm": "2.x || 3.x"
   },
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-core": "^5.8.25",
-    "babel-eslint": "^4.1.3",
-    "babel-loader": "^5.3.2",
-    "eslint": "^1.7.2",
-    "espower-babel": "^3.3.0",
+    "babel-cli": "^6.4.5",
+    "babel-core": "^6.4.5",
+    "babel-eslint": "^4.1.8",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.4.5",
+    "babel-preset-es2015": "^6.3.13",
+    "eslint": "^1.10.3",
+    "espower-babel": "^4.0.1",
     "gulp": "^3.9.0",
     "mocha": "^2.3.3",
     "power-assert": "^1.1.0",
     "pre-commit": "^1.1.2",
-    "webpack": "^1.12.2"
+    "webpack": "^1.12.13"
   },
   "dependencies": {
+    "babel-loader": "^6.2.2",
     "superagent": "^1.4.0"
   },
   "pre-commit": [

--- a/src/index.js
+++ b/src/index.js
@@ -7,30 +7,31 @@ import Transfer from './transfer';
 import Event from './event';
 import Account from './account';
 
-export default class Payjp {
-
-  constructor(apikey, config = {}) {
-    if (!apikey) {
-      throw new Error('Please set apikey.');
-    }
-
-    this.apikey = apikey;
-    this.config = this.makeConfig(config);
-
-    this.charges = new Charge(this);
-    this.customers = new Customer(this);
-    this.plans = new Plan(this);
-    this.subscriptions = new Subscription(this);
-    this.tokens = new Token(this);
-    this.transfers = new Transfer(this);
-    this.events = new Event(this);
-    this.accounts = new Account(this);
-  }
-
-  makeConfig(config) {
+function __initialize(obj, apikey, config) {
+  obj.apikey = apikey;
+  obj.config = ((_) => {
     return {
-      apibase: config.apibase || 'https://api.pay.jp/v1'
+      apibase: _.apibase || 'https://api.pay.jp/v1'
     };
+  })(config);
+
+  obj.charges = new Charge(obj);
+  obj.customers = new Customer(obj);
+  obj.plans = new Plan(obj);
+  obj.subscriptions = new Subscription(obj);
+  obj.tokens = new Token(obj);
+  obj.transfers = new Transfer(obj);
+  obj.events = new Event(obj);
+  obj.accounts = new Account(obj);
+
+  return obj;
+}
+
+export default function Payjp(apikey, config = {}) {
+
+  if (!apikey) {
+    throw new Error('Please set apikey.');
   }
 
+  return __initialize({}, apikey, config);
 }


### PR DESCRIPTION
Implemented a constructor `Payjp` that can be both function-called and constructor-called.

```js
// es6 import statement
import Payjp from 'payjp';
var payjp1 = new Payjp('apikey');

// require
var _payjp = require('payjp');
var payjp2 = new _payjp('apikey');

// callable
var payjp3 = require('payjp')('apikey');
```
