### PR TITLE
Fixed deprecated function for security reason

### DIFF
--- a/src/requestor.js
+++ b/src/requestor.js
@@ -11,7 +11,7 @@ export default class Requestor {
   }
 
   buildHeader(method) {
-    const encodedKey = new Buffer(`${this.apikey}:`).toString('base64');
+    const encodedKey = Buffer.from(`${this.apikey}:`).toString('base64');
 
     let headers = {
       Accept: 'application/json',


### PR DESCRIPTION
@wozozo 

## 概要

`new Buffer()`における初期化はdeprecatedとなり、`Buffer.from()`による初期化が推奨されています。
https://nodejs.org/dist/latest-v9.x/docs/api/buffer.html#buffer_new_buffer_array

理由としては、`new Buffer()`の引数には文字列だけでなく数値も許しており、
数値の場合、0 fillオプションを付けていないと初期化されていない領域を確保しようとします。

```
$node -v
v6.0.0
$cat deprecated.js
const sec = 'mysecretpassword';
while(1) {
    let string = (new Buffer(1024)).toString();
    if(/sec/.test(string)) {
        console.log(string);
        break;
    }
}
$node deprecated.js
... ��GmysecretpasswordH\贃8��&�prototypeH\�# ...
```

## リスク

既存の`new Buffer()`の引数にはTemplate literalで確実に文字列が渡されており、本修正を適用しなくても問題ありません。
利用者側の心理的安全と、今後の改修で誤らないよう（例えばapikeyが数値となったのでTemplate literalを外した、など）保険をかける程度のメリットとなります。

## 制限事項

`v4.5.0`以下にはバックポートされていないため、利用者はバージョンの制約を受けます。
（[`.travis.yml`](https://github.com/payjp/payjp-node/blob/master/.travis.yml)では4系以上のみ保証しているので、心配無用？）

## test/lint/build

確認済。
testには`new Buffer()`を残していますが、今回の変更が既存の処理に影響ないことを示すためです。