### PR TITLE
開発時のみ依存のpkgをdevDependenciesへ

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",
     "babel-eslint": "^7.2.3",
+    "babel-loader": "^7.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",
@@ -43,7 +44,6 @@
     "pre-commit": "^1.1.2"
   },
   "dependencies": {
-    "babel-loader": "^7.0.0",
     "superagent": "^3.5.2"
   },
   "pre-commit": [


### PR DESCRIPTION
してほしいという利用者の声がありました