### PR TITLE
Add interface to specify headers for create token

### DIFF
--- a/src/requestor.js
+++ b/src/requestor.js
@@ -29,9 +29,10 @@ export default class Requestor {
     return `${this.apibase}/${endpoint}`;
   }
 
-  request(method, endpoint, query = {}) {
+  request(method, endpoint, query = {}, headers = {}) {
     const url = this.buildUrl(endpoint);
-    const header = this.buildHeader(method);
+    const fixed_header = this.buildHeader(method);
+    const header = Object.assign(fixed_header, headers);
 
     return new Promise((resolve, reject) => {
 

--- a/src/resource.js
+++ b/src/resource.js
@@ -14,9 +14,9 @@ export default class Resource {
     return this.payjp.apikey;
   }
 
-  request(method, endpoint, query = {}) {
+  request(method, endpoint, query = {}, headers = {}) {
     const requestor = new Requestor(this.apikey, this.apibase, this.payjp.config);
-    return requestor.request(method, endpoint, query);
+    return requestor.request(method, endpoint, query, headers);
   }
 
 }

--- a/src/token.js
+++ b/src/token.js
@@ -7,8 +7,8 @@ export default class Token extends Resource {
     this.resource = 'tokens';
   }
 
-  create(query = {}) {
-    return this.request('POST', this.resource, query);
+  create(query = {}, headers = {}) {
+    return this.request('POST', this.resource, query, headers);
   }
 
   retrieve(id) {


### PR DESCRIPTION
テスト目的のトークン作成リクエストが行えるよう、`tokens.create` 時にヘッダーを指定できるようにしました

```
payjp.tokens.create(
  query = {
    card: {
      number: 4242424242424242,
      exp_month: 12,
      exp_year: 2020,
    },
  },
  headers = {
    'X-Payjp-Direct-Token-Generate': 'true'
  }
)
```