### PR TITLE
リクエスト時のエラーハンドリング改善、単体テスト改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payjp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "PAY.JP node.js bindings",
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payjp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "PAY.JP node.js bindings",
   "main": "lib/index.js",
   "keywords": [
@@ -10,9 +10,9 @@
     "api"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha --compilers js:espower-babel/guess test/**/*.js",
-    "build": "./node_modules/babel-cli/bin/babel.js ./src --out-dir ./lib",
-    "lint": "./node_modules/eslint/bin/eslint.js src",
+    "test": "mocha --compilers js:espower-babel/guess",
+    "build": "babel ./src --out-dir ./lib",
+    "lint": "eslint src",
     "prepublish": "npm run build"
   },
   "repository": {
@@ -36,7 +36,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",
-    "eslint": "^3.19.0",
+    "eslint": "^6.0.1",
     "espower-babel": "^4.0.1",
     "mocha": "^3.3.0",
     "power-assert": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payjp",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "PAY.JP node.js bindings",
   "main": "lib/index.js",
   "keywords": [
@@ -21,12 +21,13 @@
   },
   "author": "PAY.JP <support@pay.jp> (https://pay.jp)",
   "contributors": [
-    "Yoichi Fujimoto <wozozo@gmail.com>"
+    "Yoichi Fujimoto <wozozo@gmail.com>",
+    "Daiki Arai <darai0512@binc.jp>"
   ],
   "license": "MIT",
   "devEngines": {
-    "node": "4.x || 5.x",
-    "npm": "2.x || 3.x"
+    "node": "8.x || 10.x",
+    "npm": "6.x"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",

--- a/src/requestor.js
+++ b/src/requestor.js
@@ -49,11 +49,16 @@ export default class Requestor {
       }
 
       request.end((err, res) => {
-        if (res.statusCode === 200) {
-          resolve(res.body);
-        } else {
-          reject(err);
+        if (err) {
+          return reject(err);
+        } else if (res.type !== 'application/json' || res.statusCode !== 200) {
+          return reject({
+            message: 'Invalid response',
+            response: res.text,
+            status: res.status,
+          });
         }
+        return resolve(res.body);
       });
 
     });

--- a/test/account.spec.js
+++ b/test/account.spec.js
@@ -13,7 +13,7 @@ describe('Accounts Resource', () => {
   var _endpoint;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.accounts.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       return Promise.resolve();

--- a/test/card.spec.js
+++ b/test/card.spec.js
@@ -13,7 +13,7 @@ describe('Cards Resource', () => {
   var _endpoint;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.customers.cards.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       return Promise.resolve();

--- a/test/charge.spec.js
+++ b/test/charge.spec.js
@@ -13,7 +13,7 @@ describe('Charges Resource', () => {
   var _endpoint;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.charges.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       return Promise.resolve();

--- a/test/customer.spec.js
+++ b/test/customer.spec.js
@@ -13,7 +13,7 @@ describe('Customer Resource', () => {
   var _endpoint;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.customers.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       return Promise.resolve();

--- a/test/event.spec.js
+++ b/test/event.spec.js
@@ -13,7 +13,7 @@ describe('Events Resource', () => {
   var _endpoint;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.events.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       return Promise.resolve();

--- a/test/plan.spec.js
+++ b/test/plan.spec.js
@@ -13,7 +13,7 @@ describe('Plans Resource', () => {
   var _endpoint;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.plans.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       return Promise.resolve();

--- a/test/requestor.spec.js
+++ b/test/requestor.spec.js
@@ -1,7 +1,7 @@
 /* global Buffer */
 
 import assert from 'power-assert';
-
+import http from 'http';
 import Requestor from '../src/requestor';
 
 describe('HTTP Requestor', () => {
@@ -14,7 +14,7 @@ describe('HTTP Requestor', () => {
 
   describe('buildHeader', () => {
 
-    const encodedKey = new Buffer(`${'apikey'}:`).toString('base64');
+    const encodedKey = Buffer.from(`${'apikey'}:`).toString('base64');
 
     it('GET', () => {
       let header = _requestor.buildHeader('GET');
@@ -39,13 +39,148 @@ describe('HTTP Requestor', () => {
   });
 
   describe('buildUrl', () => {
-
     it('return correct endpoint', () => {
       let url = _requestor.buildUrl('charges');
       assert(url === 'https://api.pay.jp/v999/charges');
     });
-
   });
 
+  describe('request', () => {
+    it('return 200 by POST', (done) => {
+      const method = 'POST';
+      const dummy = {object: 'payjp'};
+      const apikey = 'apikey';
+      const encodedKey = Buffer.from(`${apikey}:`).toString('base64');
+      const status = 200;
+      const server = http.createServer((msg, res) => {
+        assert(!!msg.headers.host);
+        assert.strictEqual(msg.headers['accept-encoding'], 'gzip, deflate');
+        assert.strictEqual(msg.headers['user-agent'].indexOf('node-superagent/'), 0);
+        assert.strictEqual(msg.headers['content-type'], 'application/x-www-form-urlencoded');
+        assert(parseInt(msg.headers['content-length'], 10) > 0);
+        assert.strictEqual(msg.headers.accept, 'application/json');
+        assert.strictEqual(msg.headers.authorization, 'Basic ' + encodedKey);
+        assert.strictEqual(msg.headers.connection, 'close');
+        assert.strictEqual(msg.method, method);
+        assert.strictEqual(msg.url, '/v1/test');
+        let rawData = '';
+        msg.on('data', (chunk) => { rawData += chunk; });
+        msg.on('end', () => {
+          assert.strictEqual(rawData, 'object=payjp');
+          const body = JSON.stringify(dummy);
+          res.writeHead(status, {
+            'Content-Length': Buffer.byteLength(body),
+            'Content-Type': 'application/json',
+          });
+          res.end(body);
+        });
+      }).listen(() => {
+        const apibase = `http://localhost:${server.address().port}/v1`;
+        const requestor = new Requestor(apikey, apibase, {cert: null});
+        requestor.request(method, 'test', dummy).then((r) => {
+          assert.deepStrictEqual(r, dummy);
+          server.close();
+          done();
+        });
+      });
+    });
+    it('return 404 by GET', (done) => {
+      const method = 'GET';
+      const dummy = {object: 'payjp'};
+      const apikey = 'apikey';
+      const encodedKey = Buffer.from(`${apikey}:`).toString('base64');
+      const status = 404;
+      const server = http.createServer((msg, res) => {
+        assert(!!msg.headers.host);
+        assert.strictEqual(msg.headers['accept-encoding'], 'gzip, deflate');
+        assert.strictEqual(msg.headers['user-agent'].indexOf('node-superagent/'), 0);
+        assert.strictEqual(msg.headers.accept, 'application/json');
+        assert.strictEqual(msg.headers.authorization, 'Basic ' + encodedKey);
+        assert.strictEqual(msg.headers.connection, 'close');
+        assert.strictEqual(msg.method, method);
+        assert.strictEqual(msg.url, '/v1/notfound?object=payjp');
+        const body = JSON.stringify({error: {
+          message: 'test',
+          status,
+          type: 'not_found_error',
+        }});
+        res.writeHead(status, {
+          'Content-Length': Buffer.byteLength(body),
+          'Content-Type': 'application/json',
+        });
+        res.end(body);
+      }).listen(() => {
+        const apibase = `http://localhost:${server.address().port}/v1`;
+        const requestor = new Requestor(apikey, apibase, {cert: null});
+        requestor.request(method, 'notfound', dummy).catch((e) => {
+          assert.strictEqual(e.status, status);
+          assert.strictEqual(e.response.body.error.message, 'test');
+          assert.strictEqual(e.response.body.error.status, status);
+          assert.strictEqual(e.response.body.error.type, 'not_found_error');
+          server.close();
+          done();
+        });
+      });
+    });
+    it('return 200 by DELETE, but invalid response', (done) => {
+      const method = 'DELETE';
+      const apikey = 'apikey';
+      const encodedKey = Buffer.from(`${apikey}:`).toString('base64');
+      const status = 200;
+      const server = http.createServer((msg, res) => {
+        assert(!!msg.headers.host);
+        assert.strictEqual(msg.headers['accept-encoding'], 'gzip, deflate');
+        assert.strictEqual(msg.headers['user-agent'].indexOf('node-superagent/'), 0);
+        assert.strictEqual(msg.headers.accept, 'application/json');
+        assert.strictEqual(msg.headers.authorization, 'Basic ' + encodedKey);
+        assert.strictEqual(msg.headers.connection, 'close');
+        assert.strictEqual(msg.method, method);
+        assert.strictEqual(msg.url, '/v1/test');
+        res.writeHead(status, {'Content-Type': 'text/plain'});
+        res.end('<html></html>');
+      }).listen(() => {
+        const apibase = `http://localhost:${server.address().port}/v1`;
+        const requestor = new Requestor(apikey, apibase, {cert: null});
+        requestor.request(method, 'test').catch((e) => {
+          assert.deepStrictEqual(e, {
+            message: 'Invalid response',
+            status,
+            response: '<html></html>',
+          });
+          server.close();
+          done();
+        });
+      });
+    });
+    it('return Network Error: request ok, but not response', (done) => {
+      const server = http.createServer((msg, res) => {
+        assert(!!msg.headers.host);
+        return msg.socket.destroy();
+      }).listen(() => {
+        const apibase = `http://localhost:${server.address().port}/v1`;
+        const requestor = new Requestor('', apibase, {cert: null});
+        requestor.request('GET', '').catch((r) => {
+          assert.strictEqual(r.status, undefined);
+          assert.strictEqual(r.response, undefined);
+          assert.strictEqual(r.message, 'socket hang up');
+          done();
+        });
+      });
+    });
+    it('return Network Error: url not exists', (done) => {
+      const server = http.createServer();
+      server.listen(() => {
+        const apibase = `http://localhost:${server.address().port}/v1`;
+        server.close();
+        const requestor = new Requestor('', apibase, {cert: null});
+        requestor.request('GET', '').catch((r) => {
+          assert.strictEqual(r.status, undefined);
+          assert.strictEqual(r.response, undefined);
+          assert.strictEqual(r.message.indexOf('connect ECONNREFUSED'), 0);
+          done();
+        });
+      });
+    });
+  });
 
 });

--- a/test/subscription.spec.js
+++ b/test/subscription.spec.js
@@ -14,7 +14,15 @@ describe('Subscription Resource', () => {
   var _query;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.subscriptions.request = (...args) => {
+      _method = args[0];
+      _endpoint = args[1];
+      if (Object.keys(args).length > 2) {
+        _query = args[2];
+      }
+      return Promise.resolve();
+    };
+    payjp.customers.subscriptions.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       if (Object.keys(args).length > 2) {

--- a/test/token.spec.js
+++ b/test/token.spec.js
@@ -13,7 +13,7 @@ describe('Tokens Resource', () => {
   var _endpoint;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.tokens.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       return Promise.resolve();

--- a/test/transfer.spec.js
+++ b/test/transfer.spec.js
@@ -13,7 +13,7 @@ describe('Transfer Resource', () => {
   var _endpoint;
 
   before(() => {
-    Requestor.prototype.request = (...args) => {
+    payjp.transfers.request = (...args) => {
       _method = args[0];
       _endpoint = args[1];
       return Promise.resolve();


### PR DESCRIPTION
# 概要

- src/requestor.jsの`request()`のエラーハンドリングを改善
  - superagentのdocsを参考
  - http://visionmedia.github.io/superagent/#error-handling
  - `Network failures, timeouts, and other errors that produce no response will contain no err.status or err.response fields.` など
- 単体テストを追加・改善
  - src/requestor.jsの`request()`のテストを追加
  - 実際にlocalhostでserverを立ててテスト。空いてるportが自動的に選ばれる仕組み（Node.js本家のテストを参考）。HTTPヘッダー含め全てをテストして理解しておく
  - `npm test -- test/requestor.spec.js`と単発だと成功したが`npm test`では失敗。原因は他のテスト全てで`request()`がmockされ、かつ元に戻されてなかったため
  - 他のテストではインスタンスも作っていたのでそちらをmockすることで元のコードに影響が無いよう修正
- eslintのsecurity alertが出ていたのでバージョンを上げて対応

# 備考

- masterは現在リリースされていない
- masterのミラーとしてfeature/tsというブランチを作成
- リリース完了: tags/v.1.4.0