### PR TITLE
rm any type of warning on resouce.ts

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -34,7 +34,7 @@ export default class Resource {
     return headers;
   }
 
-  protected request(method: string, endpoint: string, query: object = {}, headers: object = {}): Promise<any> {
+  protected request<I>(method: string, endpoint: string, query: object = {}, headers: object = {}): Promise<I> {
     const url: string = `${this.payjp.config.apibase}/${endpoint}`;
     const header: object = Object.assign(this.buildHeader(method), headers);
 
@@ -48,6 +48,6 @@ export default class Resource {
       request = request.timeout(this.payjp.config.timeout);
     }
 
-    return request.then((res: superagent.Response): any => res.body)
+    return request.then((res: superagent.Response): I => res.body)
   }
 }


### PR DESCRIPTION
## abstract

- rm `any`, add Generics
- but omit types on every Resource to maintain easily.

```typescript
export default class Accounts extends Resource {
  retrieve(): Promise<I.Account> {
    // return this.request<I.Account>('GET', `${this.resource}`); // Good, but omit
    return this.request('GET', `${this.resource}`); // current code
  }
}
```

## check

- [x] comile as ts