### PR TITLE
fix card type

### DIFF
--- a/src/customer.ts
+++ b/src/customer.ts
@@ -22,7 +22,7 @@ class CustomerSubscriptions extends Resource {
 
 export default class Customers extends Resource {
   resource: string;
-  cards: object;
+  cards: Cards;
   subscriptions: object;
 
   constructor(payjp) {


### PR DESCRIPTION
# 問題
Customer.cardsのtypeが`object`になっており、`payjp.customers.cards.create`を呼び出す際に次のエラーが出る
```
error TS2339: Property 'delete' does not exist on type 'object'.
```

# 対処
objectをCardsに修正しました。

close #24 