### PR TITLE
組戻ステータスの追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ namespace Payjp {
   }
 
   export interface TransferListOptions extends ListOptions {
-    status?: "pending" | "paid" | "failed" | "stop" | "carried_over",
+    status?: "pending" | "paid" | "failed" | "stop" | "carried_over" | "recombination",
   }
 
   export interface TransferChargeListOptions extends ListOptions {


### PR DESCRIPTION
http://payjp-announce.hatenablog.com/entry/2020/02/14/174049 にて、2020/02/29入金予定分以降の入金失敗は組戻(recombination)と表されるので、その対応

修正対象は/v1/transfers のクエリパラーメーターのみ