### PR TITLE
add type of transfer.summary.dispute_info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ node_js:
   - "10"
   - "node"
 sudo: false
+install: yarn --frozen-lockfile
 after_success: npm run report && npm run coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payjp",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "PAY.JP node.js bindings",
   "main": "built/index.js",
   "types": "built/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,9 +298,9 @@ namespace Payjp {
     object: "token",
     card: Card,
     created: number,
-    id: string;
-    livemode: boolean;
-    used: boolean;
+    id: string,
+    livemode: boolean,
+    used: boolean,
   }
 
   interface Summary {
@@ -309,7 +309,9 @@ namespace Payjp {
     charge_gross: number,
     net: number,
     refund_amount: number,
-    refund_count: number
+    refund_count: number,
+    dispute_amount: number,
+    dispute_count: number,
   }
 
   interface TransferBase {


### PR DESCRIPTION
See http://payjp-announce.hatenablog.com/entry/2020/12/10/141657

Add types of (tenant_)transfer.summary.dispute_amount and dispute_count.

```
import * as Payjp from './src'
const payjp = Payjp('sk_test_c62fade9d045b54cd76d7036')
payjp.transfers.list({
  limit: 1,
}).then((transfers: Payjp.List<Payjp.Transfer>): number => {
    return transfers.data[0].summary.dispute_amount
}).then(console.log)
```