### PR TITLE
Migrate travis ci to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  testing:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '10', '12', '14' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: yarn --frozen-lockfile
+      - run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-  - "8"
-  - "10"
-  - "node"
-sudo: false
-install: yarn --frozen-lockfile
-after_success: npm run report && npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PAY.JP for Node.js
 
-[![Build Status](https://github.com/payjp/payjp-node/actions/workflows/test.yml/badge.svg)](https://github.com/payjp/payjp-node/actions)
+[![Build Status](https://github.com/payjp/payjp-node/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/payjp/payjp-node/actions)
 [![npm](https://img.shields.io/npm/v/payjp.svg)](payjp)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PAY.JP for Node.js
 
-[![Build Status](https://travis-ci.org/payjp/payjp-node.svg?branch=master)](https://travis-ci.org/payjp/payjp-node)
+[![Build Status](https://github.com/payjp/payjp-node/actions/workflows/test.yml/badge.svg)](https://github.com/payjp/payjp-node/actions)
 [![npm](https://img.shields.io/npm/v/payjp.svg)](payjp)
 
 ## Installation


### PR DESCRIPTION
Migrate CI from Travis CI to Github Actions.

[![Build Status](https://github.com/payjp/payjp-node/actions/workflows/test.yml/badge.svg)](https://github.com/payjp/payjp-node/actions)

lintのwarningが出てますが、別で修正していきますので一旦無視でお願いします。