### PR TITLE
3Dセキュア系APIエンドポイント/パラメータに対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm run test
+      - run: yarn --frozen-lockfile
+      - run: yarn test
       - run: npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run test
+      - run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: release
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - feature-three-d-secure
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-
 name: release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: release
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - feature-three-d-secure
 
 jobs:
 

--- a/src/charge.ts
+++ b/src/charge.ts
@@ -1,5 +1,5 @@
-import Resource from './resource';
 import * as I from './index';
+import Resource from './resource';
 
 export default class Charges extends Resource {
 
@@ -36,6 +36,10 @@ export default class Charges extends Resource {
 
   capture(id, query: I.ChargeCaptureOptions = {}): Promise<I.Charge> {
     return this.request('POST', `${this.resource}/${id}/capture`, query);
+  }
+
+  tds_finish(id): Promise<I.Charge> {
+    return this.request('POST', `${this.resource}/${id}/tds_finish`);
   }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,7 @@ namespace Payjp {
     total_platform_fee?: number,
     tenant?: string | null,
     product?: any,
+    three_d_secure_status: string | null,
   }
 
   export interface Customer {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
+import Accounts from './account';
 import Charges from './charge';
 import Customers from './customer';
+import Events from './event';
 import Plans from './plan';
 import Subscriptions from './subscription';
-import Tokens from './token';
-import Transfers from './transfer';
-import Events from './event';
-import Accounts from './account';
 import Tenants from './tenants';
 import TenantTransfers from './tenantTransfers';
+import Tokens from './token';
+import Transfers from './transfer';
 
 namespace Payjp {
   export interface PayjpStatic {
@@ -98,6 +98,7 @@ namespace Payjp {
     expiry_days?: number,
     platform_fee?: number,
     tenant?: string,
+    three_d_secure?: boolean,
   }
 
   export interface ChargeUpdateOptions extends WithMetadata {
@@ -441,7 +442,7 @@ namespace Payjp {
 
   export interface ResponseError {
     status?: number | undefined,
-    response?: {body?: PayjpError, [propName: string]: any} | undefined,
+    response?: { body?: PayjpError, [propName: string]: any } | undefined,
     message: string,
     timeout?: number,
 
@@ -462,7 +463,7 @@ const Payjp: Payjp.PayjpStatic = function (apikey: string, options: Payjp.PayjpO
       apibase: options.apibase || 'https://api.pay.jp/v1',
       timeout: options.timeout || 0,
       maxRetry: options.maxRetry || 0,
-      retryInitialDelay: options.retryInitialDelay|| 2000,
+      retryInitialDelay: options.retryInitialDelay || 2000,
       retryMaxDelay: options.retryMaxDelay || 32000,
     },
   };

--- a/test/charge.spec.js
+++ b/test/charge.spec.js
@@ -65,4 +65,13 @@ describe('Charges Resource', () => {
     });
   });
 
+  describe('tds_finish', () => {
+    it('Sends the correct request', () => {
+      return payjp.charges.tds_finish('id123').then(([_method, _endpoint]) => {
+        assert(_method === 'POST');
+        assert(_endpoint === 'charges/id123/tds_finish');
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
# 概要

3Dセキュアで追加されたAPI、パラメータに対応します。

https://pay.jp/docs/api/#charge-%E6%94%AF%E6%89%95%E3%81%84

また、パッケージリリース用のgithub actionsも追加します。

# 変更点

* /v1/chargesにthree_d_secureパラメータを追加
* /v1/charges/:id/tds_finish エンドポイントに対応