### PR TITLE
add type of card.three_d_secure_status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,7 @@ namespace Payjp {
     livemode: boolean,
     metadata: OptionsMetadata | null,
     name: string | null,
+    three_d_secure_status: string | null,
   }
 
   export interface Plan {


### PR DESCRIPTION
# Abstract

add card.three_d_secure_status for types.
About parameter, see https://pay.jp/docs/api/#card%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88