### PR TITLE
型の付いていないメソッドに対して型をつける

### DIFF
--- a/src/charge.ts
+++ b/src/charge.ts
@@ -18,27 +18,27 @@ export default class Charges extends Resource {
     return this.request('POST', this.resource, query);
   }
 
-  retrieve(id): Promise<I.Charge> {
+  retrieve(id: string): Promise<I.Charge> {
     return this.request('GET', `${this.resource}/${id}`);
   }
 
-  update(id, query: I.ChargeUpdateOptions = {}): Promise<I.Charge> {
+  update(id: string, query: I.ChargeUpdateOptions = {}): Promise<I.Charge> {
     return this.request('POST', `${this.resource}/${id}`, query);
   }
 
-  refund(id, query: I.RefundCreationOptions = {}): Promise<I.Charge> {
+  refund(id: string, query: I.RefundCreationOptions = {}): Promise<I.Charge> {
     return this.request('POST', `${this.resource}/${id}/refund`, query);
   }
 
-  reauth(id, query: I.ChargeReauthOptions = {}): Promise<I.Charge> {
+  reauth(id: string, query: I.ChargeReauthOptions = {}): Promise<I.Charge> {
     return this.request('POST', `${this.resource}/${id}/reauth`, query);
   }
 
-  capture(id, query: I.ChargeCaptureOptions = {}): Promise<I.Charge> {
+  capture(id: string, query: I.ChargeCaptureOptions = {}): Promise<I.Charge> {
     return this.request('POST', `${this.resource}/${id}/capture`, query);
   }
 
-  tds_finish(id): Promise<I.Charge> {
+  tds_finish(id: string): Promise<I.Charge> {
     return this.request('POST', `${this.resource}/${id}/tds_finish`);
   }
 

--- a/src/tenantTransfers.ts
+++ b/src/tenantTransfers.ts
@@ -13,11 +13,11 @@ export default class TenantTransfers extends Resource {
     return this.request('GET', this.resource, query);
   }
 
-  retrieve(id): Promise<I.TenantTransfer> {
+  retrieve(id: string): Promise<I.TenantTransfer> {
     return this.request('GET', `${this.resource}/${id}`);
   }
 
-  charges(id, query: I.TransferChargeListOptions = {}): Promise<I.List<I.Charge>> {
+  charges(id: string, query: I.TransferChargeListOptions = {}): Promise<I.List<I.Charge>> {
     return this.request('GET', `${this.resource}/${id}/charges`, query);
   }
 

--- a/src/tenants.ts
+++ b/src/tenants.ts
@@ -18,11 +18,11 @@ export default class Tenants extends Resource {
     return this.request('POST', this.resource, query);
   }
 
-  retrieve(id): Promise<I.Tenant> {
+  retrieve(id: string): Promise<I.Tenant> {
     return this.request('GET', `${this.resource}/${id}`);
   }
 
-  update(id, query: I.TenantUpdateOptions = {}): Promise<I.Tenant> {
+  update(id: string, query: I.TenantUpdateOptions = {}): Promise<I.Tenant> {
     return this.request('POST', `${this.resource}/${id}`, query);
   }
 


### PR DESCRIPTION
PayjpSDKの提供ありがとうございます。
普段利用させて頂いてる中で気づいた点ありましたので、以下の内容でPRを作成させていただきました。

---

## 概要

引数に対して型が指定されていないメソッドが存在し、実行時のエラーで引数の誤りに気づくことがあったため、
該当のメソッドに対して型をつけました。

## 変更点

- コード内で引数に型がついていなかったcharge, transfers, tenantTransfersについて修正を行いました。
- 型はほかのメソッドおよびAPIドキュメントをもとに `string` 型のみを受け入れ可能と判断しています