### PR TITLE
feat: add term and balance.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payjp",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "PAY.JP node.js bindings",
   "main": "built/index.js",
   "types": "built/index.d.ts",

--- a/src/balance.ts
+++ b/src/balance.ts
@@ -1,0 +1,19 @@
+import Resource from './resource';
+import * as I from './index';
+
+export default class Balances extends Resource {
+  resource: string;
+
+  constructor(payjp) {
+    super(payjp);
+    this.resource = 'balances';
+  }
+
+  list(query: I.BalanceListOptions = {}): Promise<I.List<I.Balance>> {
+    return this.request('GET', this.resource, query);
+  }
+
+  retrieve(id: string): Promise<I.Balance> {
+    return this.request('GET', `${this.resource}/${id}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,7 @@ namespace Payjp {
     tenant?: string | null,
     product?: any,
     three_d_secure_status: string | null,
+    term_id: string | null,
   }
 
   export interface Customer {

--- a/src/index.ts
+++ b/src/index.ts
@@ -429,6 +429,8 @@ namespace Payjp {
     id: string,
     livemode: boolean,
     object: "statement",
+    term: Term | null,
+    balance_id: string,
     items: List<StatementItems>,
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -449,7 +449,8 @@ namespace Payjp {
     net: number,
     term: Term | null,
     balance_id: string,
-    items: List<StatementItems>,
+    items: StatementItems[],
+    updated: number,
   }
 
   export interface StatementItems {
@@ -516,13 +517,7 @@ namespace Payjp {
     net: number,
     object: "balance",
     state: "collecting" | "transfer" | "claim",
-    statements: {
-      count: number,
-      data: List<Statement>,
-      has_more: false,
-      object: "list",
-      url: string
-    },
+    statements: Statement[],
     closed: boolean,
     due_date: null | number,
     tenant_id: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -484,6 +484,15 @@ namespace Payjp {
     start_at: number,
   }
 
+  export interface BankInfo {
+    "bank_code": string;
+    "bank_branch_code": string;
+    "bank_account_type": string;
+    "bank_account_number": string;
+    "bank_account_holder_name": string;
+    "bank_account_status": "success" | "failed" | "pending";
+  }
+
   export interface Balance {
     "created": number,
     "id": string,
@@ -500,14 +509,7 @@ namespace Payjp {
     },
     "closed": boolean,
     "due_date": null | number,
-    "bank_info": null | {
-      "bank_code": string,
-      "bank_branch_code": string,
-      "bank_account_type": string,
-      "bank_account_number": string,
-      "bank_account_holder_name": string,
-      "bank_account_status": "success" | "failed" | "pending",
-    }
+    "bank_info": null | BankInfo
   }
 
   export interface Deleted {

--- a/src/index.ts
+++ b/src/index.ts
@@ -493,7 +493,7 @@ namespace Payjp {
     "type": string,
     "statements": {
       count: number,
-      data: Statement[],
+      data: List<Statement>,
       has_more: false,
       object: "list",
       url: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,10 @@ namespace Payjp {
     transfer?: string,
     tenant?: string,
   }
+  export interface TermListOptions extends ListOptions {
+    since_start_at?: number,
+    until_start_at?: number,
+  }
 
   export interface BalanceListOptions extends ListOptions {
     since_due_date?: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,9 +43,12 @@ namespace Payjp {
     retryMaxDelay?: number,
   }
 
-  export interface ListOptions {
+  export interface PaginationOptions {
     limit?: number,
     offset?: number,
+  }
+
+  export interface ListOptions extends PaginationOptions {
     since?: number,
     until?: number,
   }
@@ -93,7 +96,7 @@ namespace Payjp {
     type?: "sales" | "service_fee" | "transfer_fee",
   }
 
-  export interface TermListOptions extends ListOptions {
+  export interface TermListOptions extends PaginationOptions {
     since_start_at?: number,
     until_start_at?: number,
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import TenantTransfers from './tenantTransfers';
 import Tokens from './token';
 import Transfers from './transfer';
 import Statements from './statement';
+import Terms from "./term";
 
 namespace Payjp {
   export interface PayjpStatic {
@@ -29,6 +30,7 @@ namespace Payjp {
     tenants: Tenants,
     tenant_transfers: TenantTransfers,
     statements: Statements,
+    terms: Terms,
   }
 
   export interface PayjpOptions {
@@ -456,6 +458,18 @@ namespace Payjp {
     total_platform_fee: number,
   }
 
+  export interface Term {
+    created: number,
+    id: string,
+    livemode: boolean,
+    object: 'term',
+    charge_count: number,
+    refund_count: number,
+    dispute_count: number,
+    end_at: number,
+    start_at: number,
+  }
+
   export interface Deleted {
     deleted: boolean,
     id: string,
@@ -515,6 +529,7 @@ const Payjp: Payjp.PayjpStatic = function (apikey: string, options: Payjp.PayjpO
     tenants: new Tenants(payjpConfig),
     'tenant_transfers': new TenantTransfers(payjpConfig),
     statements: new Statements(payjpConfig),
+    terms: new Terms(payjpConfig),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import Tokens from './token';
 import Transfers from './transfer';
 import Statements from './statement';
 import Terms from "./term";
+import Balances from "./balance";
 
 namespace Payjp {
   export interface PayjpStatic {
@@ -31,6 +32,7 @@ namespace Payjp {
     tenant_transfers: TenantTransfers,
     statements: Statements,
     terms: Terms,
+    balances: Balances,
   }
 
   export interface PayjpOptions {
@@ -80,6 +82,15 @@ namespace Payjp {
 
   export interface TenantTransferListOptions extends TransferListOptions {
     transfer?: string,
+    tenant?: string,
+  }
+
+  export interface BalanceListOptions extends ListOptions {
+    since_due_date?: number,
+    until_due_date?: number,
+    type?: string,
+    closed?: boolean,
+    owner?: "merchant" | "tenant",
     tenant?: string,
   }
 
@@ -462,12 +473,38 @@ namespace Payjp {
     created: number,
     id: string,
     livemode: boolean,
-    object: 'term',
+    object: "term",
     charge_count: number,
     refund_count: number,
     dispute_count: number,
     end_at: number,
     start_at: number,
+  }
+
+  export interface Balance {
+    "created": number,
+    "id": string,
+    "livemode": boolean,
+    "net": number,
+    "object": "balance",
+    "type": string,
+    "statements": {
+      count: number,
+      data: Statement[],
+      has_more: false,
+      object: "list",
+      url: string
+    },
+    "closed": boolean,
+    "due_date": null | number,
+    "bank_info": null | {
+      "bank_code": string,
+      "bank_branch_code": string,
+      "bank_account_type": string,
+      "bank_account_number": string,
+      "bank_account_holder_name": string,
+      "bank_account_status": "success" | "failed" | "pending",
+    }
   }
 
   export interface Deleted {
@@ -530,6 +567,7 @@ const Payjp: Payjp.PayjpStatic = function (apikey: string, options: Payjp.PayjpO
     'tenant_transfers': new TenantTransfers(payjpConfig),
     statements: new Statements(payjpConfig),
     terms: new Terms(payjpConfig),
+    balances: new Balances(payjpConfig),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -489,31 +489,31 @@ namespace Payjp {
   }
 
   export interface BankInfo {
-    "bank_code": string;
-    "bank_branch_code": string;
-    "bank_account_type": string;
-    "bank_account_number": string;
-    "bank_account_holder_name": string;
-    "bank_account_status": "success" | "failed" | "pending";
+    bank_code: string;
+    bank_branch_code: string;
+    bank_account_type: string;
+    bank_account_number: string;
+    bank_account_holder_name: string;
+    bank_account_status: "success" | "failed" | "pending";
   }
 
   export interface Balance {
-    "created": number,
-    "id": string,
-    "livemode": boolean,
-    "net": number,
-    "object": "balance",
-    "type": string,
-    "statements": {
+    created: number,
+    id: string,
+    livemode: boolean,
+    net: number,
+    object: "balance",
+    type: string,
+    statements: {
       count: number,
       data: List<Statement>,
       has_more: false,
       object: "list",
       url: string
     },
-    "closed": boolean,
-    "due_date": null | number,
-    "bank_info": null | BankInfo
+    closed: boolean,
+    due_date: null | number,
+    bank_info: null | BankInfo
   }
 
   export interface Deleted {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,15 @@ namespace Payjp {
     transfer?: string,
     tenant?: string,
   }
+
+  export interface StatementListOptions extends ListOptions {
+    owner?: "merchant" | "tenant",
+    source_transfer?: string,
+    tenant?: string,
+    term?: string,
+    type?: "sales" | "service_fee" | "transfer_fee",
+  }
+
   export interface TermListOptions extends ListOptions {
     since_start_at?: number,
     until_start_at?: number,
@@ -92,7 +101,7 @@ namespace Payjp {
   export interface BalanceListOptions extends ListOptions {
     since_due_date?: number,
     until_due_date?: number,
-    type?: string,
+    state?: "collecting" | "transfer" | "claim",
     closed?: boolean,
     owner?: "merchant" | "tenant",
     tenant?: string,
@@ -434,6 +443,10 @@ namespace Payjp {
     id: string,
     livemode: boolean,
     object: "statement",
+    title: string,
+    tenant_id: string,
+    type: "sales" | "service_fee" | "transfer_fee",
+    net: number,
     term: Term | null,
     balance_id: string,
     items: List<StatementItems>,
@@ -477,7 +490,6 @@ namespace Payjp {
   }
 
   export interface Term {
-    created: number,
     id: string,
     livemode: boolean,
     object: "term",
@@ -503,7 +515,7 @@ namespace Payjp {
     livemode: boolean,
     net: number,
     object: "balance",
-    type: string,
+    state: "collecting" | "transfer" | "claim",
     statements: {
       count: number,
       data: List<Statement>,
@@ -513,6 +525,7 @@ namespace Payjp {
     },
     closed: boolean,
     due_date: null | number,
+    tenant_id: string,
     bank_info: null | BankInfo
   }
 

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -9,7 +9,7 @@ export default class Statements extends Resource {
     this.resource = 'statements';
   }
 
-  list(query: I.TenantTransferListOptions = {}): Promise<I.List<I.Statement>> {
+  list(query: I.StatementListOptions = {}): Promise<I.List<I.Statement>> {
     return this.request('GET', this.resource, query);
   }
 

--- a/src/term.ts
+++ b/src/term.ts
@@ -1,0 +1,19 @@
+import Resource from './resource';
+import * as I from './index';
+
+export default class Terms extends Resource {
+  resource: string;
+
+  constructor(payjp) {
+    super(payjp);
+    this.resource = 'terms';
+  }
+
+  list(query: I.ListOptions = {}): Promise<I.List<I.Term>> {
+    return this.request('GET', this.resource, query);
+  }
+
+  retrieve(id: string): Promise<I.Term> {
+    return this.request('GET', `${this.resource}/${id}`);
+  }
+}

--- a/src/term.ts
+++ b/src/term.ts
@@ -9,7 +9,7 @@ export default class Terms extends Resource {
     this.resource = 'terms';
   }
 
-  list(query: I.ListOptions = {}): Promise<I.List<I.Term>> {
+  list(query: I.TermListOptions = {}): Promise<I.List<I.Term>> {
     return this.request('GET', this.resource, query);
   }
 

--- a/test/balance.spec.js
+++ b/test/balance.spec.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const Payjp = require('../built');
+const config = require('./config');
+
+const payjp = Payjp(config.apikey, config);
+payjp.balances.request = (...args) => Promise.resolve(args);
+
+describe('Balance Resource', () => {
+
+  describe('list', () => {
+    it('Sends the correct request', () => {
+      const query = {limit: 1};
+      return payjp.balances.list(query).then(([_method, _endpoint, _query]) => {
+        assert(_method === 'GET');
+        assert(_endpoint === 'balances');
+        assert.deepStrictEqual(_query, query);
+      });
+    });
+  });
+
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      return payjp.balances.retrieve('id123').then(([_method, _endpoint]) => {
+        assert(_method === 'GET');
+        assert(_endpoint === 'balances/id123');
+      });
+    });
+  });
+});

--- a/test/term.spec.js
+++ b/test/term.spec.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const Payjp = require('../built');
+const config = require('./config');
+
+const payjp = Payjp(config.apikey, config);
+payjp.terms.request = (...args) => Promise.resolve(args);
+
+describe('Term Resource', () => {
+
+  describe('list', () => {
+    it('Sends the correct request', () => {
+      const query = {limit: 1};
+      return payjp.terms.list(query).then(([_method, _endpoint, _query]) => {
+        assert(_method === 'GET');
+        assert(_endpoint === 'terms');
+        assert.deepStrictEqual(_query, query);
+      });
+    });
+  });
+
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      return payjp.terms.retrieve('id123').then(([_method, _endpoint]) => {
+        assert(_method === 'GET');
+        assert(_endpoint === 'terms/id123');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Overview
Changes due to the addition of the Term and Balance objects.

## Changes
* Add term object
https://pay.jp/docs/api/#term%E9%9B%86%E8%A8%88%E5%8C%BA%E9%96%93

* Add balance object
https://pay.jp/docs/api/#balance-%E6%AE%8B%E9%AB%98

* Add term and balance id in Statement balance object
https://pay.jp/docs/api/#statement%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88

* Add term id in charge object https://pay.jp/docs/api/#charge%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88
