### PR TITLE
update: add statement url to balance object.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payjp",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "PAY.JP node.js bindings",
   "main": "built/index.js",
   "types": "built/index.d.ts",

--- a/src/balance.ts
+++ b/src/balance.ts
@@ -16,4 +16,8 @@ export default class Balances extends Resource {
   retrieve(id: string): Promise<I.Balance> {
     return this.request('GET', `${this.resource}/${id}`);
   }
+
+  statementUrls(id: string, query: I.StatementUrlOptions = {}): Promise<I.StatementUrl> {
+    return this.request('POST', `${this.resource}/${id}/statement_urls`, query);
+  }
 }

--- a/test/balance.spec.js
+++ b/test/balance.spec.js
@@ -26,4 +26,15 @@ describe('Balance Resource', () => {
       });
     });
   });
+
+  describe('statementUrls', () => {
+    it('Sends the correct request', () => {
+      const query = {platformer: false};
+      return payjp.balances.statementUrls('id123', query).then(([_method, _endpoint, _query]) => {
+        assert(_method === 'POST');
+        assert(_endpoint === 'balances/id123/statement_urls');
+        assert.deepStrictEqual(_query, query);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Overview

Add statement url property to balance object.

## Changes

https://pay.jp/docs/api/#balance-%E6%AE%8B%E9%AB%98

https://pay.jp/docs/guideline-term-statement-balance#balance%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88