### PR TITLE
Cardオブジェクトにemail, phoneを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payjp",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "PAY.JP node.js bindings",
   "main": "built/index.js",
   "types": "built/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,6 +303,8 @@ namespace Payjp {
     metadata: OptionsMetadata | null,
     name: string | null,
     three_d_secure_status: string | null,
+    email: string | null,
+    phone: string | null,
   }
 
   export interface Plan {


### PR DESCRIPTION
- https://help.pay.jp/ja/articles/9556161 対応
- 3Dセキュアへの連携項目としてcardオブジェクトにemailとphoneが追加されたのでその対応
- version 2.2.4