### PR TITLE
feat: add endpoints about ThreeDSecureRequest object.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payjp",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "PAY.JP node.js bindings",
   "main": "built/index.js",
   "types": "built/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import Transfers from './transfer';
 import Statements from './statement';
 import Terms from "./term";
 import Balances from "./balance";
+import ThreeDSecureRequests from "./threeDSecureRequest";
 
 namespace Payjp {
   export interface PayjpStatic {
@@ -33,6 +34,7 @@ namespace Payjp {
     statements: Statements,
     terms: Terms,
     balances: Balances,
+    three_d_secure_requests: ThreeDSecureRequests,
   }
 
   export interface PayjpOptions {
@@ -546,6 +548,31 @@ namespace Payjp {
     bank_info: null | BankInfo
   }
 
+  export interface ThreeDSecureRequest {
+    object: 'three_d_secure_request',
+    id: string,
+    resource_id: string,
+    livemode: boolean,
+    created: number,
+    state: 'created' | 'in_progress' | 'result_received' | 'finished',
+    started_at: null | number,
+    result_received_at: null | number,
+    finished_at: null | number,
+    expired_at: null | number,
+    tenant_id: null | string,
+    three_d_secure_status: ThreeDSecureStatus,
+  }
+
+  export interface ThreeDSecureRequestCreationOptions {
+    resource_id: string,
+    tenant_id?: string,
+  }
+
+  export interface ThreeDSecureRequestListOptions extends ListOptions {
+    resource_id?: string,
+    tenant_id?: string,
+  }
+
   export interface Deleted {
     deleted: boolean,
     id: string,
@@ -607,6 +634,7 @@ const Payjp: Payjp.PayjpStatic = function (apikey: string, options: Payjp.PayjpO
     statements: new Statements(payjpConfig),
     terms: new Terms(payjpConfig),
     balances: new Balances(payjpConfig),
+    three_d_secure_requests: new ThreeDSecureRequests(payjpConfig),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ namespace Payjp {
     livemode: boolean,
     metadata: OptionsMetadata | null,
     name: string | null,
-    three_d_secure_status: string | null,
+    three_d_secure_status: ThreeDSecureStatus,
     email: string | null,
     phone: string | null,
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,8 @@ namespace Payjp {
     url: string
   }
 
+  type ThreeDSecureStatus = null | 'unverified' | 'verified' | 'attempted' | 'failed' | 'error';
+
   export interface Charge {
     object: "charge",
     amount: number,
@@ -264,7 +266,7 @@ namespace Payjp {
     total_platform_fee?: number,
     tenant?: string | null,
     product?: any,
-    three_d_secure_status: string | null,
+    three_d_secure_status: ThreeDSecureStatus,
     term_id: string | null,
   }
 

--- a/src/threeDSecureRequest.ts
+++ b/src/threeDSecureRequest.ts
@@ -1,0 +1,24 @@
+import Resource from './resource';
+import * as I from './index';
+
+export default class ThreeDSecureRequests extends Resource {
+  resource: string;
+
+  constructor(payjp) {
+    super(payjp);
+    this.resource = 'three_d_secure_requests';
+  }
+
+  list(query: I.ThreeDSecureRequestListOptions = {}): Promise<I.List<I.ThreeDSecureRequest>> {
+    return this.request('GET', this.resource, query);
+  }
+
+  create(query: I.ThreeDSecureRequestCreationOptions): Promise<I.ThreeDSecureRequest> {
+    return this.request('POST', this.resource, query);
+  }
+
+  retrieve(id: string): Promise<I.ThreeDSecureRequest> {
+    return this.request('GET', `${this.resource}/${id}`);
+  }
+
+}

--- a/test/threeDSecureRequest.spec.js
+++ b/test/threeDSecureRequest.spec.js
@@ -22,9 +22,10 @@ describe('ThreeDSecureRequest Resource', () => {
       const query = {
         resource_id: 'car_xxxxxxxxxxxxxxxxxxxxxxxxx'
       };
-      return payjp.three_d_secure_requests.create(query).then(([_method, _endpoint]) => {
+      return payjp.three_d_secure_requests.create(query).then(([_method, _endpoint, _query]) => {
         assert(_method === 'POST');
         assert(_endpoint === 'three_d_secure_requests');
+        assert.deepStrictEqual(_query, query);
       });
     });
   });

--- a/test/threeDSecureRequest.spec.js
+++ b/test/threeDSecureRequest.spec.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const Payjp = require('../built');
+const config = require('./config');
+
+const payjp = Payjp(config.apikey, config);
+payjp.three_d_secure_requests.request = (...args) => Promise.resolve(args);
+
+describe('ThreeDSecureRequest Resource', () => {
+  describe('list', () => {
+    it('Sends the correct request', () => {
+      return payjp.three_d_secure_requests.list().then(([_method, _endpoint]) => {
+        assert(_method === 'GET');
+        assert(_endpoint === 'three_d_secure_requests');
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('Sends the correct request', () => {
+      const query = {
+        resource_id: 'car_xxxxxxxxxxxxxxxxxxxxxxxxx'
+      };
+      return payjp.three_d_secure_requests.create(query).then(([_method, _endpoint]) => {
+        assert(_method === 'POST');
+        assert(_endpoint === 'three_d_secure_requests');
+      });
+    });
+  });
+
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      return payjp.three_d_secure_requests.retrieve('id123').then(([_method, _endpoint]) => {
+        assert(_method === 'GET');
+        assert(_endpoint === 'three_d_secure_requests/id123');
+      });
+    });
+  });
+
+});

--- a/test/threeDSecureRequest.spec.js
+++ b/test/threeDSecureRequest.spec.js
@@ -8,9 +8,11 @@ payjp.three_d_secure_requests.request = (...args) => Promise.resolve(args);
 describe('ThreeDSecureRequest Resource', () => {
   describe('list', () => {
     it('Sends the correct request', () => {
-      return payjp.three_d_secure_requests.list().then(([_method, _endpoint]) => {
+      const query = {limit: 1};
+      return payjp.three_d_secure_requests.list(query).then(([_method, _endpoint, _query]) => {
         assert(_method === 'GET');
         assert(_endpoint === 'three_d_secure_requests');
+        assert.deepStrictEqual(_query, query);
       });
     });
   });


### PR DESCRIPTION
## Overview

add endpoints about ThreeDSecureRequest object.

* [3Dセキュアリクエストを作成 – PAY.JP API リファレンス](https://pay.jp/docs/api/#3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%82%92%E4%BD%9C%E6%88%90)
* [3Dセキュアリクエスト情報を取得 – PAY.JP API リファレンス](https://pay.jp/docs/api/#3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E6%83%85%E5%A0%B1%E3%82%92%E5%8F%96%E5%BE%97)
* [3Dセキュアリクエストリストを取得 – PAY.JP API リファレンス](https://pay.jp/docs/api/#3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%83%AA%E3%82%B9%E3%83%88%E3%82%92%E5%8F%96%E5%BE%97)

