### PR TITLE
feat: add support for nested metadata serialization in request bodies and query strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ payjp.charges.create({
   currency: 'jpy',
   card: 'token_id_by_Checkout_or_payjp.js'
 }).then(console.log).catch(console.error);
+
+payjp.charges.create({
+  amount: 1000,
+  currency: 'jpy',
+  customer: 'cus_xxx',
+  metadata: { user_id: 123 }
+}).then(console.log).catch(console.error);
 ```
 
 Typescript

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -38,6 +38,33 @@ export default class Resource {
     return Math.ceil((delay / 2) * (1 + Math.random()));
   }
 
+  private isPlainObject(value: unknown): value is Record<string, unknown> {
+    return Object.prototype.toString.call(value) === "[object Object]";
+  }
+
+  private appendFormValue(params: URLSearchParams, key: string, value: unknown): void {
+    if (value === undefined) {
+      return;
+    }
+
+    if (this.isPlainObject(value)) {
+      for (const [nestedKey, nestedValue] of Object.entries(value)) {
+        this.appendFormValue(params, `${key}[${nestedKey}]`, nestedValue);
+      }
+      return;
+    }
+
+    params.append(key, String(value));
+  }
+
+  private serializeQuery(query: object): URLSearchParams {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      this.appendFormValue(params, key, value);
+    }
+    return params;
+  }
+
   protected request<I>(
     method: string,
     endpoint: string,
@@ -56,14 +83,14 @@ export default class Resource {
       // Set query parameters or request body
       if (method === "GET" || method === "DELETE") {
         // For GET and DELETE, add query parameters to URL
-        const params = new URLSearchParams(query as Record<string, string>);
+        const params = this.serializeQuery(query);
         const queryString = params.toString();
         if (queryString) {
           url = `${url}?${queryString}`;
         }
       } else {
         // For POST and PUT, send as request body
-        const body = new URLSearchParams(query as Record<string, string>);
+        const body = this.serializeQuery(query);
         fetchOptions.body = body.toString();
       }
 

--- a/test/requestor.spec.js
+++ b/test/requestor.spec.js
@@ -112,6 +112,74 @@ describe("HTTP Requestor", () => {
           });
         });
     });
+    it("serializes nested object values for POST bodies", (done) => {
+      const dummy = {
+        amount: 100,
+        metadata: { user: 121899 },
+      };
+      const status = 200;
+      const server = http
+        .createServer((msg, res) => {
+          server.close();
+          assert.strictEqual(msg.method, "POST");
+          assert.strictEqual(msg.url, "/v1/charges");
+          let rawData = "";
+          msg.on("data", (chunk) => {
+            rawData += chunk;
+          });
+          msg.on("end", () => {
+            assert.strictEqual(rawData, "amount=100&metadata%5Buser%5D=121899");
+            const body = JSON.stringify(dummy);
+            res.writeHead(status, {
+              "Content-Length": Buffer.byteLength(body),
+              "Content-Type": "application/json",
+            });
+            res.end(body);
+          });
+        })
+        .listen(() => {
+          const apibase = `http://localhost:${server.address().port}/v1`;
+          const payjp = new Payjp(apikey, { apibase });
+          payjp.charges.create(dummy).then((r) => {
+            assert.deepStrictEqual(r, dummy);
+            done();
+          });
+        });
+    });
+    it("keeps flat bracket notation keys for POST bodies", (done) => {
+      const dummy = {
+        amount: 100,
+        "metadata[user]": "test",
+      };
+      const status = 200;
+      const server = http
+        .createServer((msg, res) => {
+          server.close();
+          assert.strictEqual(msg.method, "POST");
+          assert.strictEqual(msg.url, "/v1/charges");
+          let rawData = "";
+          msg.on("data", (chunk) => {
+            rawData += chunk;
+          });
+          msg.on("end", () => {
+            assert.strictEqual(rawData, "amount=100&metadata%5Buser%5D=test");
+            const body = JSON.stringify(dummy);
+            res.writeHead(status, {
+              "Content-Length": Buffer.byteLength(body),
+              "Content-Type": "application/json",
+            });
+            res.end(body);
+          });
+        })
+        .listen(() => {
+          const apibase = `http://localhost:${server.address().port}/v1`;
+          const payjp = new Payjp(apikey, { apibase });
+          payjp.charges.create(dummy).then((r) => {
+            assert.deepStrictEqual(r, dummy);
+            done();
+          });
+        });
+    });
     it("return 400 by GET", (done) => {
       const dummy = { object: "payjp" };
       const status = 400;
@@ -141,6 +209,58 @@ describe("HTTP Requestor", () => {
             assert.strictEqual(e.response.body.error.message, "test");
             assert.strictEqual(e.response.body.error.status, status);
             assert.strictEqual(e.response.body.error.type, "client_error");
+            done();
+          });
+        });
+    });
+    it("serializes nested object values for GET query strings", (done) => {
+      const dummy = {
+        metadata: { user: 121899 },
+      };
+      const status = 200;
+      const server = http
+        .createServer((msg, res) => {
+          server.close();
+          assert.strictEqual(msg.method, "GET");
+          assert.strictEqual(msg.url, "/v1/charges?metadata%5Buser%5D=121899");
+          const body = JSON.stringify({});
+          res.writeHead(status, {
+            "Content-Length": Buffer.byteLength(body),
+            "Content-Type": "application/json",
+          });
+          res.end(body);
+        })
+        .listen(() => {
+          const apibase = `http://localhost:${server.address().port}/v1`;
+          const payjp = new Payjp(apikey, { apibase });
+          payjp.charges.request("GET", "charges", dummy).then((r) => {
+            assert.deepStrictEqual(r, {});
+            done();
+          });
+        });
+    });
+    it("keeps flat bracket notation keys for GET query strings", (done) => {
+      const dummy = {
+        "metadata[user]": "test",
+      };
+      const status = 200;
+      const server = http
+        .createServer((msg, res) => {
+          server.close();
+          assert.strictEqual(msg.method, "GET");
+          assert.strictEqual(msg.url, "/v1/charges?metadata%5Buser%5D=test");
+          const body = JSON.stringify({});
+          res.writeHead(status, {
+            "Content-Length": Buffer.byteLength(body),
+            "Content-Type": "application/json",
+          });
+          res.end(body);
+        })
+        .listen(() => {
+          const apibase = `http://localhost:${server.address().port}/v1`;
+          const payjp = new Payjp(apikey, { apibase });
+          payjp.charges.request("GET", "charges", dummy).then((r) => {
+            assert.deepStrictEqual(r, {});
             done();
           });
         });


### PR DESCRIPTION
## 概要

`v3.0.0` で `superagent` から `fetch` への移行時に発生した、`metadata: { ... }` のようなネストオブジェクトの `application/x-www-form-urlencoded` への不正なシリアライズの修正。

`metadata: { user: 121899 }` のような従来の指定方法のサポート復元。

## 変更内容

- `src/resource.ts`
  - form-urlencoded 用の共通 serializer の追加
  - plain object の再帰的な bracket 記法への展開
  - GET/DELETE の query string と POST/PUT の request body における共通 serializer の利用

- 互換性
  - `metadata: { user: "test" }` のような object 形式の正式サポート
  - `"metadata[user]": "test"` 形式の後方互換維持

- `README.md`
  - `metadata` を object で指定する利用例の追加

## テスト

`test/requestor.spec.js` への以下のケースの追加。

- POST body における `metadata: { user: 121899 }` の `metadata[user]=121899` への展開
- GET query string における `metadata: { user: 121899 }` の `metadata[user]=121899` への展開
- POST body における `"metadata[user]": "test"` の送信互換性
- GET query string における `"metadata[user]": "test"` の送信互換性
