### PR TITLE
feat: add is_jp field to Card interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -307,6 +307,7 @@ namespace Payjp {
     three_d_secure_status: ThreeDSecureStatus;
     email: string | null;
     phone: string | null;
+    is_jp: boolean;
   }
 
   export interface Plan {


### PR DESCRIPTION
ドキュメントサイトにて、Cardに `is_jp` プロパティが追加されていたので、型に追記させていただきました。

> `is_jp` Boolean
> 国内発行カードなら `true`、海外発行カードなら `false`

参照: https://docs.pay.jp/v1/api/#card%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88
