### PR TITLE
feat: add is_jp field to Card interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -307,6 +307,7 @@ namespace Payjp {
     three_d_secure_status: ThreeDSecureStatus;
     email: string | null;
     phone: string | null;
+    is_jp: boolean;
   }
 
   export interface Plan {


### PR DESCRIPTION
## 概要

PAY.JP API の Card オブジェクトに `is_jp` プロパティが追加されている (国内発行カードなら `true`、海外発行カードなら `false`) ため、`Card` interface の型定義に追記します。

- 参照: https://docs.pay.jp/v1/api/#card%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88

## 変更内容

- `src/index.ts` の `Card` interface に `is_jp: boolean;` を 1 行追加

## 動作確認

- `npm run build` で型チェック通過
- `npm test` で既存 89 件すべて通過
- ローカル API エンドポイントに対し SDK 経由で `payjp.customers.cards.retrieve()` を実行し、レスポンスの `card.is_jp` に TypeScript から `boolean` として型安全にアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)